### PR TITLE
Added simple demo avoidance and RELEASE flag

### DIFF
--- a/hivemind.py
+++ b/hivemind.py
@@ -97,8 +97,7 @@ class Beehive(PythonHivemind):
             if time <= 0.2:
                 for drone in self.drones:
                     if (
-                        drone.car.on_ground
-                        and (drone.index == index1 or drone.index == index2)
+                        (drone.index == index1 or drone.index == index2)
                         and isinstance(drone.maneuver, (ShadowDefense, Refuel))
                         ):
                         self.logger.debug(f"Drone {drone.index} is avoiding the collision!")

--- a/hivemind.py
+++ b/hivemind.py
@@ -6,12 +6,16 @@ from rlbot.utils.structures.bot_input_struct import PlayerInput
 from rlbot.utils.structures.game_data_struct import GameTickPacket
 
 from maneuvers.kickoffs.kickoff import Kickoff
+from maneuvers.shadow_defense import ShadowDefense
+from maneuvers.refuel import Refuel
 from rlutilities.linear_algebra import vec3
 from strategy.hivemind_strategy import HivemindStrategy
 from utils.drawing import DrawingTool
 from utils.drone import Drone
 from utils.game_info import GameInfo
 
+
+RELEASE = True
 
 class Beehive(PythonHivemind):
     def __init__(self, *args):
@@ -35,7 +39,7 @@ class Beehive(PythonHivemind):
         self.drones = [Drone(self.info.cars[i], i) for i in self.drone_indices]
 
         self.logger.handlers[0].setLevel(logging.NOTSET)  # override handler level
-        self.logger.setLevel(logging.DEBUG)  # change level here (DEBUG, INFO, etc.)
+        self.logger.setLevel(logging.INFO if RELEASE else logging.DEBUG)
         self.logger.info("Beehive initialized")
 
     def get_outputs(self, packet: GameTickPacket) -> Dict[int, PlayerInput]:
@@ -84,6 +88,27 @@ class Beehive(PythonHivemind):
             # expire finished maneuvers
             if drone.maneuver.finished:
                 drone.maneuver = None
+
+        # demo avoidance
+        collisions = self.info.detect_collisions(time_limit=0.2, dt=1/60)
+        for collision in collisions:
+            index1, index2, time = collision
+            self.logger.debug(f"Collision: {index1} ->*<- {index2} in {time:.2f} seconds.")
+            if time <= 0.2:
+                for drone in self.drones:
+                    if (
+                        drone.car.on_ground
+                        and (drone.index == index1 or drone.index == index2)
+                        and isinstance(drone.maneuver, (ShadowDefense, Refuel))
+                        ):
+                        self.logger.debug(f"Drone {drone.index} is avoiding the collision!")
+                        drone.controls.jump = True
+                        break
+
+        # render predictions
+        # for prediction in [self.info.predict_car_drive(i) for i in range(self.info.num_cars)]:
+        #     self.draw.color(self.draw.yellow)
+        #     self.draw.polyline(prediction)
 
         self.strategy.render(self.draw)
         self.draw.execute()

--- a/maneuvers/air/recovery.py
+++ b/maneuvers/air/recovery.py
@@ -14,7 +14,7 @@ class Recovery(Maneuver):
     def __init__(self, car: Car, jump_when_upside_down=True):
         super().__init__(car)
 
-        self.jump_when_upside_down = True
+        self.jump_when_upside_down = jump_when_upside_down
         self.landing = False
         self.aerial_turn = AerialTurn(self.car)
 

--- a/maneuvers/driving/travel.py
+++ b/maneuvers/driving/travel.py
@@ -64,7 +64,7 @@ class Travel(Maneuver):
                     if car_speed > 1200 and not use_boost_instead:
                         if time_left > self.DODGE_DURATION:
                             dodge = Dodge(car)
-                            dodge.duration = 0.05
+                            dodge.duration = 0.07
                             dodge.direction = vec2(direction(car, target))
                             self.action = dodge
                             self.driving = False

--- a/utils/game_info.py
+++ b/utils/game_info.py
@@ -115,7 +115,7 @@ class GameInfo(Game):
         collisions = []
         for i in range(self.num_cars):
             for j in range(self.num_cars):
-                if i <= j: 
+                if i >= j: 
                     continue
 
                 for step in range(time_steps):


### PR DESCRIPTION
Avoid demos by predicting all cars (circles / straight lines) and finding when they get close enough. Once a collision is found, a drone which is either Refueling or ShadowDefending will jump to avoid it. Only one drone will jump per collision. Drones will not jump if doing a strike for example (so that 50/50s and similar are not affected).

The prediction could be rewritten in something like numpy for parallelisation since it does computes each position independently (which also means it is accurate for large dt).

The `RELEASE` flag currently only toggles logging level between `INFO` and `DEBUG`, but maybe you can use it elsewhere as well (to help with performance when it matters).